### PR TITLE
support for multi tenancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ I get a lot of requests for assistance with IdentityNow API integration so here 
 
 ## Installation ##
 
-The dependencies are PowerShell version 5 and the PowerShell Community eXtension. The manual installation and module scripts should install the PSCx module automatically for you. If for some reason (like you're on an airgapped network), you can get [PSCx it from here](https://github.com/Pscx/Pscx)
+The dependencies are PowerShell version 5 and the PowerShell Community eXtension. If for some reason (like you're on an airgapped network), you can get [PSCx it from here](https://github.com/Pscx/Pscx)
 
 To install either...
 
@@ -53,7 +53,7 @@ or
 
 * From an Admin PowerShell session, install from the PowerShell Gallery 
 ```
-install-module -name SailPointIdentityNow
+install-module -name pscx
 ```
 
 ## Examples ##
@@ -83,6 +83,18 @@ install-module -name SailPointIdentityNow
     $v2Creds = [pscredential]::new($clientID, ($clientSecret | ConvertTo-SecureString -AsPlainText -Force))
 
     Set-IdentityNowCredential -AdminCredential $adminCreds -v2APIKey $v2Creds -v3APIKey $v3Creds 
+    Save-IdentityNowConfiguration
+```
+
+or with credential prompts
+
+```
+    Set-IdentityNowOrg 'myPrimaryIDNOrg'
+    Set-IdentityNowCredential
+    Save-IdentityNowConfiguration -default
+
+    Set-IdentityNowOrg 'mySecondaryIDNOrg'
+    Set-IdentityNowCredential
     Save-IdentityNowConfiguration
 ```
 

--- a/SailPointIdentityNow.psd1
+++ b/SailPointIdentityNow.psd1
@@ -38,7 +38,8 @@
         'New-IdentityNowIdentityProfilesReport',
         'New-IdentityNowOAuthAPIClient',
         'New-IdentityNowRole',
-        'New-IdentityNowSource'
+        'New-IdentityNowSource',
+        'New-IdentityNowSourceAccountSchemaAttribute',
         'New-IdentityNowSourceConfigReport',
         'New-IdentityNowUserSourceAccount',
         'New-IdentityNowTransform',

--- a/SailPointIdentityNow.psd1
+++ b/SailPointIdentityNow.psd1
@@ -6,6 +6,7 @@
     Copyright         = '(c) 2019 . All rights reserved.'
     Description       = "Orchestration of SailPoint IdentityNow via REST API's using Powershell"
     PowerShellVersion = '5.0'
+    RequiredModules   = @(@{ModuleName="pscx"; ModuleVersion="3.3.2"})
     FunctionsToExport = @('Complete-IdentityNowTask',
         'Get-IdentityNowAccessProfile',
         'Get-IdentityNowAccountActivities',

--- a/SailPointIdentityNow.psd1
+++ b/SailPointIdentityNow.psd1
@@ -6,7 +6,6 @@
     Copyright         = '(c) 2019 . All rights reserved.'
     Description       = "Orchestration of SailPoint IdentityNow"
     PowerShellVersion = '5.0'
-    RequiredModules   = @(@{ModuleName="pscx"; ModuleVersion="3.3.2"})
     FunctionsToExport = @('Complete-IdentityNowTask',
         'Get-IdentityNowAccessProfile',
         'Get-IdentityNowAccountActivities',

--- a/SailPointIdentityNow.psd1
+++ b/SailPointIdentityNow.psd1
@@ -59,6 +59,7 @@
         'Set-IdentityNowCredential',
         'Set-IdentityNowOrg',
         'Start-IdentityNowCertCampaign',
+        'Test-IdentityNowSourceConnection',
         'Update-IdentityNowAccessProfile',
         'Update-IdentityNowApplication',
         'Update-IdentityNowEmailTemplate',

--- a/SailPointIdentityNow.psd1
+++ b/SailPointIdentityNow.psd1
@@ -37,6 +37,7 @@
         'New-IdentityNowGovernanceGroup',
         'New-IdentityNowOAuthAPIClient',
         'New-IdentityNowRole',
+        'New-IdentityNowSource'
         'New-IdentityNowUserSourceAccount',
         'New-IdentityNowTransform',
         'Remove-IdentityNowAccessProfile',

--- a/SailPointIdentityNow.psm1
+++ b/SailPointIdentityNow.psm1
@@ -1,4 +1,4 @@
-$IdentityNowConfiguration = @{    
+$IdentityNowConfiguration = @{
     orgName = $null 
     v2  = $null
     v3  = $null

--- a/SailPointIdentityNow.psm1
+++ b/SailPointIdentityNow.psm1
@@ -14,7 +14,8 @@ if ($null -ne $IdentityNowConfiguration.DefaultOrg){
     Set-IdentityNowOrg -orgName $IdentityNowConfiguration.DefaultOrg
 }
 
-#if (-not(Get-Module -ListAvailable -Name pscx)) {Install-Module -Name Pscx -RequiredVersion 3.3.2 -Force -AllowClobber}
+if (-not(Get-Module -ListAvailable -Name pscx)) {Install-Module -Name Pscx -RequiredVersion 3.3.2 -Force -AllowClobber}
+#if (-not(Get-Module -ListAvailable -Name jwtdetails)) {Install-Module -Name jwtdetails  -Force -AllowClobber}
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 Get-ChildItem "$PSScriptRoot/scripts/*.ps1" | ForEach-Object { . $_ }

--- a/SailPointIdentityNow.psm1
+++ b/SailPointIdentityNow.psm1
@@ -10,7 +10,7 @@ if (Test-Path $IdentityNowConfigurationFile) {
     $IdentityNowConfiguration = Import-Clixml $IdentityNowConfigurationFile
 }
 
-if (-not(Get-Module -ListAvailable -Name pscx)) {Install-Module -Name Pscx -RequiredVersion 3.3.2 -Force -AllowClobber}
+#if (-not(Get-Module -ListAvailable -Name pscx)) {Install-Module -Name Pscx -RequiredVersion 3.3.2 -Force -AllowClobber}
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 Get-ChildItem "$PSScriptRoot/scripts/*.ps1" | ForEach-Object { . $_ }

--- a/SailPointIdentityNow.psm1
+++ b/SailPointIdentityNow.psm1
@@ -3,11 +3,15 @@ $IdentityNowConfiguration = @{
     v2  = $null
     v3  = $null
     AdminCredential = $null
+    DefaultOrg = $null
 }
 
 $IdentityNowConfigurationFile = Join-Path $env:LOCALAPPDATA IdentityNowConfiguration.clixml
 if (Test-Path $IdentityNowConfigurationFile) {
     $IdentityNowConfiguration = Import-Clixml $IdentityNowConfigurationFile
+}
+if ($null -ne $IdentityNowConfiguration.DefaultOrg){
+    Set-IdentityNowOrg -orgName $IdentityNowConfiguration.DefaultOrg
 }
 
 #if (-not(Get-Module -ListAvailable -Name pscx)) {Install-Module -Name Pscx -RequiredVersion 3.3.2 -Force -AllowClobber}

--- a/scripts/Get-IdentityNowSourceAccounts.ps1
+++ b/scripts/Get-IdentityNowSourceAccounts.ps1
@@ -46,7 +46,7 @@ function Get-IdentityNowSourceAccounts {
                     [int]$offset = $offset + $searchLimit
                     $results = Invoke-RestMethod -Method Get -Uri "https://$($IdentityNowConfiguration.orgName).api.identitynow.com/v2/accounts?sourceId=$($sourceID)&limit=$($searchLimit)&offset=$($offset)&org=$($IdentityNowConfiguration.orgName)" -Headers $Headersv2
                     if ($results) {
-                        $sourceObjects += $results                        
+                        $sourceObjects += $results
                     }
                 }
             } until ($results.Count -lt $searchLimit)

--- a/scripts/New-IdentityNowSource.ps1
+++ b/scripts/New-IdentityNowSource.ps1
@@ -1,0 +1,76 @@
+function new-IdentityNowSource {
+        <#
+.SYNOPSIS
+Create an IdentityNow Source.
+
+.DESCRIPTION
+Create an IdentityNow Source.
+
+.PARAMETER name
+(Required - string) The name of the new IdentityNow Source.
+
+.PARAMETER description
+(string) The description of the new IdentityNow Source. 
+
+.PARAMETER connectorname
+(Required) name of an available connector this source will use, for instance 'JDBC', 'Active Directory', 'Azure Active Directory', 'Web Services', or 'ServiceNow'
+
+.PARAMETER sourcetype
+(Required) must be 'DIRECT_CONNECT' for connecting to a source or 'DELIMITED_FILE' for flat file source
+
+.EXAMPLE
+new-IdentityNowSource -name 'Dev - JDBC - ASQL - Users Table' -description 'Azure SQL users table' -connectorname 'JDBC' -sourcetype DIRECT_CONNECT
+
+.LINK
+http://darrenjrobinson.com/sailpoint-identitynow
+
+.NOTES
+written by Sean McGovern 11/20/2019 (twitter @410sean)
+
+#>
+    [cmdletbinding()]
+        param(
+            [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+            [string]$name, 
+            [string]$description, 
+            [string]$connectorname, 
+            [validateset('DIRECT_CONNECT','DELIMITED_FILE')][string]$sourcetype
+        )
+    # IdentityNow Admin User
+    $adminUSR = [string]$IdentityNowConfiguration.AdminCredential.UserName.ToLower()
+    $adminPWDClear = [System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($IdentityNowConfiguration.AdminCredential.Password))
+
+    # Generate the password hash
+    # Requires Get-Hash from PowerShell Community Extensions (PSCX) Module 
+    # https://www.powershellgallery.com/packages/Pscx/3.2.2
+    $passwordHash = Get-Hash -Algorithm SHA256 -StringEncoding utf8 -InputObject ($($adminPWDClear) + (Get-Hash -Algorithm SHA256 -StringEncoding utf8 -InputObject ($adminUSR)).HashString.ToLower())
+    $adminPWD = $passwordHash.ToString().ToLower() 
+
+    $clientSecretv3 = [System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($IdentityNowConfiguration.v3.Password))
+    # Basic Auth
+    $Bytesv3 = [System.Text.Encoding]::utf8.GetBytes("$($IdentityNowConfiguration.v3.UserName):$($clientSecretv3)")
+    $encodedAuthv3 = [Convert]::ToBase64String($Bytesv3)
+    $Headersv3 = @{Authorization = "Basic $($encodedAuthv3)" }
+
+    # Get v3 oAuth Token
+    # oAuth URI
+    $oAuthURI = "https://$($IdentityNowConfiguration.orgName).api.identitynow.com/oauth/token"
+    $v3Token = Invoke-RestMethod -Method Post -Uri "$($oAuthURI)?grant_type=password&username=$($adminUSR)&password=$($adminPWD)" -Headers $Headersv3 
+    if ($v3Token.access_token) {
+        try {
+            $privateuribase="https://$($IdentityNowConfiguration.orgName).api.identitynow.com"
+            $url="$privateuribase/cc/api/source/create"
+            $body="serviceDefinitionName=$connectorname&name=$name&description=$description&sourceType=$sourcetype&serviceType=app"
+            $response=Invoke-WebRequest -Uri $url -Method Post -UseBasicParsing -Body $body -ContentType 'application/x-www-form-urlencoded' -Headers @{Authorization = "$($v3Token.token_type) $($v3Token.access_token)"}
+            $sourceAccountProfile=$response.Content | ConvertFrom-Json
+            return $sourceAccountProfile
+        }
+        catch {
+            Write-Error "Creation of new Source failed. Check Source Configuration. $($_)" 
+        }
+    }
+    else {
+        Write-Error "Authentication Failed. Check your AdminCredential and v3 API ClientID and ClientSecret. $($_)"
+        return $v3Token
+    } 
+}

--- a/scripts/New-IdentityNowSource.ps1
+++ b/scripts/New-IdentityNowSource.ps1
@@ -1,4 +1,4 @@
-function new-IdentityNowSource {
+function New-IdentityNowSource {
         <#
 .SYNOPSIS
 Create an IdentityNow Source.

--- a/scripts/New-IdentityNowSourceAccountSchemaAttribute.ps1
+++ b/scripts/New-IdentityNowSourceAccountSchemaAttribute.ps1
@@ -1,0 +1,98 @@
+function New-IdentityNowSourceAccountSchemaAttribute {
+        <#
+.SYNOPSIS
+discover or add to a source's account schema.
+
+.DESCRIPTION
+Discover an IdentityNow Source Schema or add new attributes that may be imported.
+
+.PARAMETER sourceID
+(Required) IdentityNow Source ID.
+
+.PARAMETER discover
+this function may be run with just the Source ID and discover switch to trigger IdentityNows discover feature which will autopopulate the Account Schema
+
+.PARAMETER name
+the attribute name we wish to add to the account schema
+
+.PARAMETER type
+the attribute type
+
+.PARAMETER description
+a description of the attribute
+
+.PARAMETER multivalue
+a switch to indicate this attribute is multivalued
+
+.EXAMPLE
+new-IdentityNowSource -name 'Dev - JDBC - ASQL - Users Table' -description 'Azure SQL users table' -connectorname 'JDBC' -sourcetype DIRECT_CONNECT
+
+.LINK
+http://darrenjrobinson.com/sailpoint-identitynow
+
+.NOTES
+written by Sean McGovern 11/20/2019 (twitter @410sean)
+
+#>
+    [cmdletbinding()]
+        param(
+            [Parameter(ParameterSetName='Discover',Mandatory = $true)]
+            [switch]$discover,
+            [Parameter(ParameterSetName='Add',Mandatory = $true, ValueFromPipeline = $true)]
+            [string]$name, 
+            [Parameter(ParameterSetName='Add',Mandatory = $false, ValueFromPipeline = $true)]
+            [string]$description, 
+            [Parameter(ParameterSetName='Add',Mandatory = $true, ValueFromPipeline = $true)]
+            [string]$type,
+            [Parameter(ParameterSetName='Add',Mandatory = $false, ValueFromPipeline = $true)]
+            [switch]$multivalued            
+        )
+    # IdentityNow Admin User
+    $adminUSR = [string]$IdentityNowConfiguration.AdminCredential.UserName.ToLower()
+    $adminPWDClear = [System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($IdentityNowConfiguration.AdminCredential.Password))
+
+    # Generate the password hash
+    # Requires Get-Hash from PowerShell Community Extensions (PSCX) Module 
+    # https://www.powershellgallery.com/packages/Pscx/3.2.2
+    $passwordHash = Get-Hash -Algorithm SHA256 -StringEncoding utf8 -InputObject ($($adminPWDClear) + (Get-Hash -Algorithm SHA256 -StringEncoding utf8 -InputObject ($adminUSR)).HashString.ToLower())
+    $adminPWD = $passwordHash.ToString().ToLower() 
+
+    $clientSecretv3 = [System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($IdentityNowConfiguration.v3.Password))
+    # Basic Auth
+    $Bytesv3 = [System.Text.Encoding]::utf8.GetBytes("$($IdentityNowConfiguration.v3.UserName):$($clientSecretv3)")
+    $encodedAuthv3 = [Convert]::ToBase64String($Bytesv3)
+    $Headersv3 = @{Authorization = "Basic $($encodedAuthv3)" }
+
+    # Get v3 oAuth Token
+    # oAuth URI
+    $oAuthURI = "https://$($IdentityNowConfiguration.orgName).api.identitynow.com/oauth/token"
+    $v3Token = Invoke-RestMethod -Method Post -Uri "$($oAuthURI)?grant_type=password&username=$($adminUSR)&password=$($adminPWD)" -Headers $Headersv3 
+    if ($v3Token.access_token) {
+        try {
+            $privateuribase="https://$($IdentityNowConfiguration.orgName).api.identitynow.com"
+            if ($discover){
+                $url="$privateuribase/cc/api/source/discoverSchema/$sourceid"
+                $response=Invoke-WebRequest -Uri $url -Method Post -UseBasicParsing -Headers $headerv3
+                $sourceSchema=$response.Content | ConvertFrom-Json
+                return $sourceSchema
+            }else{
+                $url="$privateuribase/cc/api/source/createSchemaAttribute/$sourceid"
+                if ($multivalued -ne $true){
+                    $body="name=$name&description=$description&type=$type&objectType=account"
+                }else{
+                    $body="name=$name&description=$description&type=$type&multi=true&objectType=account"
+                }
+                $response=Invoke-WebRequest -Uri $url -Method Post -UseBasicParsing -Headers $headerv3 -Body $body
+                $sourceSchema=$response.Content | ConvertFrom-Json
+                return $sourceSchema
+            }
+        }
+        catch {
+            Write-Error "Creation of new Source failed. Check Source Configuration. $($_)" 
+        }
+    }
+    else {
+        Write-Error "Authentication Failed. Check your AdminCredential and v3 API ClientID and ClientSecret. $($_)"
+        return $v3Token
+    } 
+}

--- a/scripts/Remove-IdentityNowSource.ps1
+++ b/scripts/Remove-IdentityNowSource.ps1
@@ -1,0 +1,63 @@
+function Remove-IdentityNowSource {
+    <#
+.SYNOPSIS
+Deletes an IdentityNow Source.
+
+.DESCRIPTION
+Deletes an IdentityNow Source.
+
+.PARAMETER sourceid
+(Required - Integer) The ID of the IdentityNow Source.
+
+.EXAMPLE
+Remove-IdentityNowSource -sourceid 115737
+
+.LINK
+http://darrenjrobinson.com/sailpoint-identitynow
+
+.NOTES
+written by Sean McGovern 11/20/2019 (twitter @410sean)
+
+#>
+[cmdletbinding()]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [string]$sourceid
+    )
+# IdentityNow Admin User
+$adminUSR = [string]$IdentityNowConfiguration.AdminCredential.UserName.ToLower()
+$adminPWDClear = [System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($IdentityNowConfiguration.AdminCredential.Password))
+
+# Generate the password hash
+# Requires Get-Hash from PowerShell Community Extensions (PSCX) Module 
+# https://www.powershellgallery.com/packages/Pscx/3.2.2
+$passwordHash = Get-Hash -Algorithm SHA256 -StringEncoding utf8 -InputObject ($($adminPWDClear) + (Get-Hash -Algorithm SHA256 -StringEncoding utf8 -InputObject ($adminUSR)).HashString.ToLower())
+$adminPWD = $passwordHash.ToString().ToLower() 
+
+$clientSecretv3 = [System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($IdentityNowConfiguration.v3.Password))
+# Basic Auth
+$Bytesv3 = [System.Text.Encoding]::utf8.GetBytes("$($IdentityNowConfiguration.v3.UserName):$($clientSecretv3)")
+$encodedAuthv3 = [Convert]::ToBase64String($Bytesv3)
+$Headersv3 = @{Authorization = "Basic $($encodedAuthv3)" }
+
+# Get v3 oAuth Token
+# oAuth URI
+$oAuthURI = "https://$($IdentityNowConfiguration.orgName).api.identitynow.com/oauth/token"
+$v3Token = Invoke-RestMethod -Method Post -Uri "$($oAuthURI)?grant_type=password&username=$($adminUSR)&password=$($adminPWD)" -Headers $Headersv3 
+if ($v3Token.access_token) {
+    try {
+        $privateuribase="https://$($IdentityNowConfiguration.orgName).api.identitynow.com"
+        $url="$privateuribase/cc/api/source/delete/$sourceid"
+        $response=Invoke-WebRequest -Uri $url -Method Post -UseBasicParsing -Headers @{Authorization = "$($v3Token.token_type) $($v3Token.access_token)"}
+        $sourceAccountProfile=$response.Content | ConvertFrom-Json
+        return $sourceAccountProfile
+    }
+    catch {
+        Write-Error "Creation of new Source failed. Check Source Configuration. $($_)" 
+    }
+}
+else {
+    Write-Error "Authentication Failed. Check your AdminCredential and v3 API ClientID and ClientSecret. $($_)"
+    return $v3Token
+} 
+}

--- a/scripts/Save-IdentityNowConfiguration.ps1
+++ b/scripts/Save-IdentityNowConfiguration.ps1
@@ -17,7 +17,8 @@ function Save-IdentityNowConfiguration {
 #>
 
     [CmdletBinding()]
-    param ()
+    param ([switch]$default)
+    if ($default){$IdentityNowConfiguration.DefaultOrg=$IdentityNowConfiguration.orgName}
     $IdentityNowConfiguration.($IdentityNowConfiguration.orgName)=@{
         orgName = $IdentityNowConfiguration.orgName 
         v2  = $IdentityNowConfiguration.v2

--- a/scripts/Save-IdentityNowConfiguration.ps1
+++ b/scripts/Save-IdentityNowConfiguration.ps1
@@ -18,6 +18,11 @@ function Save-IdentityNowConfiguration {
 
     [CmdletBinding()]
     param ()
-
+    $IdentityNowConfiguration.($IdentityNowConfiguration.orgName)=@{
+        orgName = $IdentityNowConfiguration.orgName 
+        v2  = $IdentityNowConfiguration.v2
+        v3  = $IdentityNowConfiguration.v3
+        AdminCredential = $IdentityNowConfiguration.AdminCredential
+    }
     Export-Clixml -Path $IdentityNowConfigurationFile -InputObject $IdentityNowConfiguration
 }

--- a/scripts/Set-IdentityNowOrg.ps1
+++ b/scripts/Set-IdentityNowOrg.ps1
@@ -27,5 +27,8 @@ function Set-IdentityNowOrg {
 
     process {
         $IdentityNowConfiguration.OrgName = $orgName
+        if ($null -ne $IdentityNowConfiguration.($orgName).AdminCredential){$IdentityNowConfiguration.AdminCredential = $IdentityNowConfiguration.($orgName).AdminCredential}
+        if ($null -ne $IdentityNowConfiguration.($orgName).v2){$IdentityNowConfiguration.v2 = $IdentityNowConfiguration.($orgName).v2}
+        if ($null -ne $IdentityNowConfiguration.($orgName).v3){$IdentityNowConfiguration.v3 = $IdentityNowConfiguration.($orgName).v3}
     }
 }

--- a/scripts/Test-IdentityNowSourceConnection.ps1
+++ b/scripts/Test-IdentityNowSourceConnection.ps1
@@ -1,16 +1,16 @@
-function Remove-IdentityNowSource {
+function Test-IdentityNowSourceConnection {
     <#
 .SYNOPSIS
-Deletes an IdentityNow Source.
+Tests connection on an IdentityNow Source.
 
 .DESCRIPTION
-Deletes an IdentityNow Source. this will often fail if tasks are running or the source is in use by a transform or access profile
+Test connection an IdentityNow Source.
 
 .PARAMETER sourceid
 (Required) The ID of the IdentityNow Source.
 
 .EXAMPLE
-Remove-IdentityNowSource -sourceid 115737
+Test-IdentityNowSourceConnection -sourceid 115340
 
 .LINK
 http://darrenjrobinson.com/sailpoint-identitynow
@@ -47,13 +47,13 @@ $v3Token = Invoke-RestMethod -Method Post -Uri "$($oAuthURI)?grant_type=password
 if ($v3Token.access_token) {
     try {
         $privateuribase="https://$($IdentityNowConfiguration.orgName).api.identitynow.com"
-        $url="$privateuribase/cc/api/source/delete/$sourceid"
+        $url="$privateuribase/cc/api/source/testConnection/$sourceid"
         $response=Invoke-WebRequest -Uri $url -Method Post -UseBasicParsing -Headers @{Authorization = "$($v3Token.token_type) $($v3Token.access_token)"}
-        $sourceAccountProfile=$response.Content | ConvertFrom-Json
-        return $sourceAccountProfile
+        $source=$response.Content | ConvertFrom-Json
+        return $source
     }
     catch {
-        Write-Error "deletion of Source failed. if the following error message states 'currently in use' that could be equivalent to 'tasks are running' $($_)" 
+        Write-Error "test connection of Source failed. $($_)" 
     }
 }
 else {


### PR DESCRIPTION
- moved pscx module to required module in manifest

- save-identitynowconfiguration now can accept default switch to save the org as one which should be brought up when loading the sailpointidentitynow module

- set-identitynoworg will check for saved credentials for the provided org and make them the live credentials

- updated readme