### PR TITLE
Update Get-IdentityNowRole.ps1

### DIFF
--- a/scripts/Get-IdentityNowRole.ps1
+++ b/scripts/Get-IdentityNowRole.ps1
@@ -86,7 +86,7 @@ http://darrenjrobinson.com/sailpoint-identitynow
                 -Uri $uri `
                 -Headers $headers
             if ($countFlag) {
-                $count = [int] $response.Headers["X-Total-Count"][0]
+                $count = [int] $response.Headers["X-Total-Count"]
                 Write-Verbose "Expecting $count result"
             }
             $roles += $response.Content | ConvertFrom-Json


### PR DESCRIPTION
Line 89 :
$count = [int] $response.Headers["X-Total-Count"][0]
Count value is not correct due to the [0]

Good value with : 
$count = [int] $response.Headers["X-Total-Count"]